### PR TITLE
OE0-98: return policy object after executing service

### DIFF
--- a/policy/gql_mutations.py
+++ b/policy/gql_mutations.py
@@ -51,6 +51,7 @@ def update_or_create_policy(data, user):
         policy = Policy.objects.create(**data)
     policy.save()
     update_insuree_policies(policy, user.id_for_audit)
+    return policy
 
 
 class CreateRenewOrUpdatePolicyMutation(OpenIMISMutation):


### PR DESCRIPTION
related to TICKET: https://openimis.atlassian.net/browse/OE0-98
necessary to use this policy object in FHIR Serializer in POST Contract. Without this CI in FHIR will fail on test POST contract