### PR TITLE
OPL-91: Move Policy business logic from GQL mutations to services, signal for calcrule

### DIFF
--- a/policy/gql_mutations.py
+++ b/policy/gql_mutations.py
@@ -1,5 +1,5 @@
 import graphene
-from policy.services import update_insuree_policies
+from policy.services import update_insuree_policies, PolicyService
 
 from .apps import PolicyConfig
 from core.schema import OpenIMISMutation
@@ -24,36 +24,6 @@ class PolicyInputType(OpenIMISMutation.Input):
     officer_id = graphene.Int(required=True)
 
 
-def reset_policy_before_update(policy):
-    policy.enroll_date = None
-    policy.start_date = None
-    policy.expiry_date = None
-    policy.value = None
-    policy.product_id = None
-    policy.family_id = None
-    policy.officer_id = None
-
-
-def update_or_create_policy(data, user):
-    if "client_mutation_id" in data:
-        data.pop('client_mutation_id')
-    if "client_mutation_label" in data:
-        data.pop('client_mutation_label')
-    policy_uuid = data.pop('policy_uuid') if 'policy_uuid' in data else None
-    # update_or_create(uuid=policy_uuid, ...)
-    # doesn't work because of explicit attempt to set null to uuid!
-    if policy_uuid:
-        policy = Policy.objects.get(uuid=policy_uuid)
-        policy.save_history()
-        reset_policy_before_update(policy)
-        [setattr(policy, key, data[key]) for key in data]
-    else:
-        policy = Policy.objects.create(**data)
-    policy.save()
-    update_insuree_policies(policy, user.id_for_audit)
-    return policy
-
-
 class CreateRenewOrUpdatePolicyMutation(OpenIMISMutation):
     @classmethod
     def do_mutate(cls, perms, user, **data):
@@ -68,7 +38,7 @@ class CreateRenewOrUpdatePolicyMutation(OpenIMISMutation):
         data['audit_user_id'] = user.id_for_audit
         from core.utils import TimeUtils
         data['validity_from'] = TimeUtils.now()
-        update_or_create_policy(data, user)
+        PolicyService(user).update_or_create(data, user)
         return None
 
 
@@ -130,22 +100,6 @@ class RenewPolicyMutation(CreateRenewOrUpdatePolicyMutation):
                 'detail': str(exc)}]
 
 
-def set_policy_suspended(user, policy):
-    try:
-        policy.save_history()
-        policy.status = Policy.STATUS_SUSPENDED
-        policy.audit_user_id = user.id_for_audit
-        policy.save()
-        return []
-    except Exception as exc:
-        return {
-            'title': policy.uuid,
-            'list': [{
-                'message': _("policy.mutation.failed_to_suspend_policy") % {'uuid': policy.uuid},
-                'detail': policy.uuid}]
-        }
-
-
 class SuspendPoliciesMutation(OpenIMISMutation):
     _mutation_module = "policy"
     _mutation_class = "SuspendPolicyMutation"
@@ -171,7 +125,7 @@ class SuspendPoliciesMutation(OpenIMISMutation):
                             "policy.mutation.id_does_not_exist") % {'id': policy_uuid}}]
                     }
                     continue
-                errors += set_policy_suspended(user, policy)
+                errors += PolicyService(user).set_suspended(user, policy)
             if len(errors) == 1:
                 errors = errors[0]['list']
             return errors
@@ -179,19 +133,6 @@ class SuspendPoliciesMutation(OpenIMISMutation):
             return [{
                 'message': _("policy.mutation.failed_to_suspend_policy"),
                 'detail': str(exc)}]
-
-
-def set_policy_deleted(policy):
-    try:
-        policy.delete_history()
-        return []
-    except Exception as exc:
-        return {
-            'title': policy.uuid,
-            'list': [{
-                'message': _("policy.mutation.failed_to_change_status_of_policy") % {'policy': str(policy)},
-                'detail': policy.uuid}]
-        }
 
 
 class DeletePoliciesMutation(OpenIMISMutation):
@@ -217,7 +158,7 @@ class DeletePoliciesMutation(OpenIMISMutation):
                         "policy.validation.id_does_not_exist") % {'id': policy_uuid}}]
                 }
                 continue
-            errors += set_policy_deleted(policy)
+            errors += PolicyService(user).set_deleted(policy)
         if len(errors) == 1:
             errors = errors[0]['list']
         return errors

--- a/policy/services.py
+++ b/policy/services.py
@@ -11,7 +11,9 @@ from django.db.models import Q, Count, Min, Max, Value
 from django.db.models import Sum, F
 from django.db.models.functions import Coalesce
 from django.template import Template, Context
+from django.utils.translation import gettext as _
 from graphene.utils.str_converters import to_snake_case
+from core.signals import register_service_signal
 from insuree.models import Insuree, Family, InsureePolicy
 from insuree.services import create_insuree_renewal_detail
 from medical.models import Service, Item
@@ -21,6 +23,68 @@ from policy.utils import MonthsAdd
 from .models import Policy, PolicyRenewal
 
 logger = logging.getLogger(__name__)
+
+
+def reset_policy_before_update(policy):
+    policy.enroll_date = None
+    policy.start_date = None
+    policy.expiry_date = None
+    policy.value = None
+    policy.product_id = None
+    policy.family_id = None
+    policy.officer_id = None
+
+
+class PolicyService:
+    def __init__(self, user):
+        self.user = user
+
+    @register_service_signal('policy_service.create_or_update')
+    def update_or_create(self, data, user):
+        if "client_mutation_id" in data:
+            data.pop('client_mutation_id')
+        if "client_mutation_label" in data:
+            data.pop('client_mutation_label')
+        policy_uuid = data.pop('policy_uuid') if 'policy_uuid' in data else None
+        # update_or_create(uuid=policy_uuid, ...)
+        # doesn't work because of explicit attempt to set null to uuid!
+        if policy_uuid:
+            policy = Policy.objects.get(uuid=policy_uuid)
+            policy.save_history()
+            reset_policy_before_update(policy)
+            [setattr(policy, key, data[key]) for key in data]
+        else:
+            policy = Policy.objects.create(**data)
+        policy.save()
+        update_insuree_policies(policy, user.id_for_audit)
+        return policy
+
+    def set_suspended(self, user, policy):
+        try:
+            policy.save_history()
+            policy.status = Policy.STATUS_SUSPENDED
+            policy.audit_user_id = user.id_for_audit
+            policy.save()
+            return []
+        except Exception as exc:
+            return {
+                'title': policy.uuid,
+                'list': [{
+                    'message': _("policy.mutation.failed_to_suspend_policy") % {'uuid': policy.uuid},
+                    'detail': policy.uuid}]
+            }
+
+    def set_deleted(self, policy):
+        try:
+            policy.delete_history()
+            return []
+        except Exception as exc:
+            return {
+                'title': policy.uuid,
+                'list': [{
+                    'message': _("policy.mutation.failed_to_change_status_of_policy") % {'policy': str(policy)},
+                    'detail': policy.uuid}]
+            }
 
 
 @core.comparable

--- a/policy/signals.py
+++ b/policy/signals.py
@@ -1,5 +1,24 @@
-from core.signals import Signal
-
+from calculation.services import run_calculation_rules
+from core.models import User
+from core.service_signals import ServiceSignalBindType
+from core.signals import Signal, bind_service_signal
+from policy.models import Policy
 
 _check_formal_sector_for_policy_signal_params = ["user", "policy_id"]
 signal_check_formal_sector_for_policy = Signal(providing_args=_check_formal_sector_for_policy_signal_params)
+
+
+def bind_service_signals():
+    bind_service_signal(
+        'policy_service.create_or_update',
+        on_policy_create_or_update,
+        bind_type=ServiceSignalBindType.AFTER
+    )
+
+
+def on_policy_create_or_update(**kwargs):
+    policy = kwargs.get('result', None)
+    if policy:
+        if policy.status in [Policy.STATUS_IDLE, Policy.STATUS_ACTIVE]:
+            user = User.objects.filter(i_user__id=policy.audit_user_id).first()
+            run_calculation_rules(policy, "PolicyCreated", user)


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OPL-91

Changes:
- Moved business logic from gql mutations to services
- Adjusted mutations code to use new services
