### PR TITLE
OTC-889: fix product filtering in resolve_policy_values

### DIFF
--- a/.github/workflows/openmis-module-test.yml
+++ b/.github/workflows/openmis-module-test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     services:
       mssql:
         image: mcr.microsoft.com/mssql/server:2017-latest

--- a/policy/schema.py
+++ b/policy/schema.py
@@ -92,9 +92,14 @@ class Query(graphene.ObjectType):
 
     def resolve_policy_values(self, info, **kwargs):
 
-        # product = Product.objects.get(id=kwargs.get('product_id'))
         product = Product.objects.filter(
-            (Q(id=kwargs.get('product_id')) | Q(legacy_id=kwargs.get('product_id'))) & Q(validity_from__lte=kwargs.get('enrollDate'))).order_by('-validity_from')[:1][0]
+            Q(validity_to__isnull=True),
+            Q(id=kwargs.get('product_id')) | Q(legacy_id=kwargs.get('product_id')),
+            Q(validity_from__date__lte=kwargs.get('enrollDate')),
+        ).order_by('-validity_from').first()
+
+        if not product:
+            raise ValidationError('Provided product not available')
 
         policy = PolicyGQLType(
             stage=kwargs.get('stage'),


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-889

This PR changes query to filter the product by the start of a day of its validity. It also adds a check to see if product's validity is null.