### PR TITLE
OTC-1016: added additional claim perms check for policy by insuree query

### DIFF
--- a/policy/schema.py
+++ b/policy/schema.py
@@ -1,3 +1,4 @@
+from claim.apps import ClaimConfig
 from core.schema import (
     OrderedDjangoFilterConnectionField,
     signal_mutation_module_validate,
@@ -190,7 +191,8 @@ class Query(graphene.ObjectType):
         )
 
     def resolve_policies_by_insuree(self, info, **kwargs):
-        if not info.context.user.has_perms(PolicyConfig.gql_query_policies_by_insuree_perms):
+        if not info.context.user.has_perms(PolicyConfig.gql_query_policies_by_insuree_perms) \
+                and not info.context.user.has_perms(ClaimConfig.gql_query_claims_perms):
             raise PermissionDenied(_("unauthorized"))
         req = ByInsureeRequest(
             chf_id=kwargs.get('chf_id'),


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1016

Changes:
- in Policy module there is special query dedicated for insurees_by_familty which is used in the claim page. It was missing check for claim perms. In Legacy version it was fixed by adding policy perms to the ClaimAdmin.