### PR TITLE
OTC-1080: test are not crashing on postgresql

### DIFF
--- a/policy/test_helpers.py
+++ b/policy/test_helpers.py
@@ -1,5 +1,5 @@
 from contribution.models import Premium
-from insuree.models import InsureePolicy
+from insuree.models import InsureePolicy, Family, Gender, Insuree
 from policy.models import Policy
 from product.models import Product
 
@@ -119,3 +119,42 @@ def create_test_policy_with_IPs(product, insuree, valid=True, policy_props=None,
     )
 
     return policy
+
+
+def create_test_insuree_for_policy(with_family=True, is_head=False, custom_props=None, family_custom_props=None):
+    # To establish the mandatory reference between "Insuree" and "Family" objects, we can insert the "Family" object
+    # with a temporary ID and later update it to associate with the respective "Insuree" object.
+    if with_family:
+        family = Family.objects.create(
+            validity_from="2019-01-01",
+            head_insuree_id=1,  # dummy
+            audit_user_id=-1,
+            **(family_custom_props if family_custom_props else {})
+        )
+    else:
+        family = None
+
+    insuree = Insuree.objects.create(
+        **{
+            "last_name": "Test Last",
+            "other_names": "First Second",
+            "chf_id": "chf_dflt",
+            "family": family,
+            "gender": Gender.objects.get(code='M'),
+            "dob": "1970-01-01",
+            "head": is_head,
+            "card_issued": True,
+            "validity_from": "2019-01-01",
+            "audit_user_id": -1,
+            **(custom_props if custom_props else {})
+        }
+    )
+    insuree.save()
+    if with_family:
+        family.head_insuree_id = insuree.id
+        if family_custom_props:
+            for k, v in family_custom_props.items():
+                setattr(family, k, v)
+        family.save()
+
+    return insuree, family

--- a/policy/test_services.py
+++ b/policy/test_services.py
@@ -455,7 +455,6 @@ class RenewalsTestCase(TestCase):
         self.assertEquals(policy_not_expired_yet.status, Policy.STATUS_ACTIVE)
 
         # tearDown
-        family.delete()
         inspolicy_expiring.delete()
         policy_expiring.delete()
         inspolicy_not_expired_yet.delete()
@@ -463,6 +462,7 @@ class RenewalsTestCase(TestCase):
         officer.delete()
         product.delete()
         insuree.delete()
+        family.delete()
 
     def test_renewals_sms(self):
         # Given

--- a/policy/test_services.py
+++ b/policy/test_services.py
@@ -412,9 +412,6 @@ class RenewalsTestCase(TestCase):
         self.assertIsNone(should_not_renew)
 
         # tearDown
-        # family_sample = Family.objects.all()
-        # print(family_sample)
-        # family_sample.delete()
         family.delete()
         renewals.delete()
         inspolicy_expiring.delete()

--- a/policy/test_services.py
+++ b/policy/test_services.py
@@ -352,7 +352,6 @@ class EligibilityServiceTestCase(TestCase):
         self.assertIsNotNone(response)
         self.assertEquals(response.total_admissions_left, 444719)
 
-        family.delete()
         signal_eligibility_service_before.disconnect(signal_before)
         claim.dedrems.all().delete()
         claim_item.delete()
@@ -364,6 +363,7 @@ class EligibilityServiceTestCase(TestCase):
         policy.delete()
         product.delete()
         insuree.delete()
+        family.delete()
 
 
 class RenewalsTestCase(TestCase):
@@ -412,7 +412,6 @@ class RenewalsTestCase(TestCase):
         self.assertIsNone(should_not_renew)
 
         # tearDown
-        family.delete()
         renewals.delete()
         inspolicy_expiring.delete()
         policy_expiring.delete()
@@ -421,6 +420,7 @@ class RenewalsTestCase(TestCase):
         officer.delete()
         product.delete()
         insuree.delete()
+        family.delete()
 
     def test_update_renewals(self):
         # Given
@@ -581,8 +581,6 @@ class RenewalsTestCase(TestCase):
         self.assertTrue("HOF\nCHFMARK\nTest Last First Second\n\n" in old_sms[0])
 
         # tearDown
-        family_newpic.delete()
-        family_oldpic.delete()
         renewals_old.first().details.all().delete()
         renewals_old.delete()
         renewals_new.first().details.all().delete()
@@ -596,4 +594,6 @@ class RenewalsTestCase(TestCase):
         photo_newpic.delete()
         photo_oldpic.delete()
         insuree_oldpic.delete()
+        family_oldpic.delete()
         insuree_newpic.delete()
+        family_newpic.delete()

--- a/policy/test_services.py
+++ b/policy/test_services.py
@@ -518,7 +518,6 @@ class RenewalsTestCase(TestCase):
         self.assertIn("Test product VISIT", officer_sms[0].sms_message)
 
         # tearDown
-        family.delete()
         officer.policy_renewals.all().delete()
         policy_expiring.insuree_policies.all().delete()
         policy_expiring.delete()
@@ -527,6 +526,7 @@ class RenewalsTestCase(TestCase):
         officer.delete()
         product.delete()
         insuree.delete()
+        family.delete()
 
     def test_insert_renewal_details(self):
         # Given


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1080

Changes:
- postgresql test are compatible with PostgreSQL. Some test are skipped when database is not "mssql"