### PR TITLE
ONI-29: Added new field to policy GQL.

### DIFF
--- a/policy/apps.py
+++ b/policy/apps.py
@@ -21,6 +21,7 @@ DEFAULT_CFG = {
     "ACTIVATION_OPTION_CONTRIBUTION": 1,
     "CTIVATION_OPTION_PAYMENT": 2,
     "ACTIVATION_OPTION_READY": 3,
+    "contribution_receipt_length": 5
 }
 
 
@@ -44,6 +45,7 @@ class PolicyConfig(AppConfig):
     ACTIVATION_OPTION_PAYMENT = None
     ACTIVATION_OPTION_READY = None
     activation_option = None
+    contribution_receipt_length = None
 
     def __load_config(self, cfg):
         for field in cfg:

--- a/policy/gql_mutations.py
+++ b/policy/gql_mutations.py
@@ -29,6 +29,7 @@ class PolicyInputType(OpenIMISMutation.Input):
     family_id = graphene.Int(required=True)
     officer_id = graphene.Int(required=True)
     is_paid = graphene.Boolean(required=False)
+    receipt = graphene.String(required=False)
 
 
 class CreateRenewOrUpdatePolicyMutation(OpenIMISMutation):

--- a/policy/gql_mutations.py
+++ b/policy/gql_mutations.py
@@ -28,6 +28,7 @@ class PolicyInputType(OpenIMISMutation.Input):
     product_id = graphene.Int(required=True)
     family_id = graphene.Int(required=True)
     officer_id = graphene.Int(required=True)
+    is_paid = graphene.Boolean(required=False)
 
 
 class CreateRenewOrUpdatePolicyMutation(OpenIMISMutation):

--- a/policy/services.py
+++ b/policy/services.py
@@ -50,6 +50,8 @@ class PolicyService:
 
     @register_service_signal('policy_service.update')
     def update_policy(self, data, user):
+        if "is_paid" in data:
+            data.pop("is_paid")
         data = self._clean_mutation_info(data)
         policy_uuid = data.pop('uuid') if 'uuid' in data else None
         policy = Policy.objects.get(uuid=policy_uuid)
@@ -62,6 +64,7 @@ class PolicyService:
 
     @register_service_signal('policy_service.create')
     def create_policy(self, data, user):
+        is_paid = data.pop("is_paid", False)
         data = self._clean_mutation_info(data)
         policy = Policy.objects.create(**data)
         policy.save()


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/ONI-29

FE PR: https://github.com/openimis/openimis-fe-policy_js/pull/79

Changes:
- Added specific field to graphql to create contribution with policy in single mutation
- Added contribution_receipt_length to settings - determines how long will be autogenerated code in format:
"RE-{product.code}-{enroll_date}-{code}". Default 5 - it should allow to create up to 99999 policies with a given product on a single day.
- If is_paid is true (only during creating of a policy) contribution is created automatically.