### PR TITLE
OP-1791: Block policy dates in the future.

### DIFF
--- a/policy/services.py
+++ b/policy/services.py
@@ -43,6 +43,8 @@ class PolicyService:
     @register_service_signal('policy_service.create_or_update')
     def update_or_create(self, data, user):
         policy_uuid = data.get('uuid', None)
+        if 'enroll_date' in data and data['enroll_date'] > py_date.today():
+            raise ValidationError("policy.enroll_date_in_the_future")
         if policy_uuid:
             return self.update_policy(data, user)
         else:


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/OP-1791

Changes:
- Throw an error if enroll date of a policy is in the future.