### PR TITLE
fix(PolicyRenewals): Handle policy renewal errors to prevent script t…

### DIFF
--- a/policy/tasks.py
+++ b/policy/tasks.py
@@ -41,13 +41,16 @@ def get_policies_for_renewal(
             break
     else:
         location = None
-    insert_renewals(
-        date_from,
-        date_to,
-        officer_id=officer,
-        reminding_interval=interval,
-        location_id=location,
-    )
+    try:
+        insert_renewals(
+            date_from,
+            date_to,
+            officer_id=officer,
+            reminding_interval=interval,
+            location_id=location,
+        )
+    except Exception as e:
+        logger.error("Error on insert_renewals %s", e)
     update_renewals()
     sms_queue = policy_renewal_sms(
         family_message_template, date_from, date_to, sms_header_template


### PR DESCRIPTION
We occasionally encounter some errors in the insert_renewals() function. 
Sometimes when an error occurs, it prevents the rest of the code from 
executing, particularly the update_renewals() function which doesn't run.
